### PR TITLE
blacklist more non-fact works by default

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -41,7 +41,7 @@ can lead to situations where you may see one-word pronoun facts that can be anno
 For this reason, you can customize the setting ``FACTS_WORD_BLACKLIST``, which should be a list of words
 that will result in a fact being stored. Generally this will be pronouns. The default value for this is::
 
-    FACTS_WORD_BLACKLIST = ['who', 'what', 'where', 'when', 'why', 'how']
+    FACTS_WORD_BLACKLIST = ['who', 'what', 'where', 'when', 'why', 'how', 'and', 'hmm', 'huh', 'no', 'oh', 'ok', 'right', 'well', 'yes']
 
 Note that this only occurs for facts that do not include ``<reply>``. This will still work::
 

--- a/helga_facts.py
+++ b/helga_facts.py
@@ -17,7 +17,7 @@ logger = log.getLogger(__name__)
 
 
 BLACKLIST = getattr(settings, 'FACTS_WORD_BLACKLIST',
-                    ['who', 'what', 'where', 'when', 'why', 'how'])
+                    ['who', 'what', 'where', 'when', 'why', 'how', 'and', 'hmm', 'huh', 'no', 'oh', 'ok', 'right', 'well', 'yes'])
 
 
 def term_regex(term):


### PR DESCRIPTION
Add some other expressions that should not result in fact storage: "hmm", "huh", "no", "oh", "ok", "right", "yes"

This fixes the case where I say in the chat:

```
  <ktdreyer> hmm is there a ticket for that?
```

and then later a user says:

```
  <otheruser> hmm?
```
